### PR TITLE
two-space indent

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1776,7 +1776,7 @@ class Line:
         if not self:
             return "\n"
 
-        indent = "    " * self.depth
+        indent = "  " * self.depth
         leaves = iter(self.leaves)
         first = next(leaves)
         res = f"{first.prefix}{indent}{first.value}"
@@ -2089,7 +2089,7 @@ class LineGenerator(Visitor[Line]):
         if prev_siblings_are(
             leaf.parent, [None, token.NEWLINE, token.INDENT, syms.simple_stmt]
         ) and is_multiline_string(leaf):
-            prefix = "    " * self.current_line.depth
+            prefix = "  " * self.current_line.depth
             docstring = fix_docstring(leaf.value[3:-3], prefix)
             leaf.value = leaf.value[0:3] + docstring + leaf.value[-3:]
             normalize_string_quotes(leaf)


### PR DESCRIPTION
Using this as a stop-gap to make initial changes more clearly, and then we can adopt 4-spaces later (if we want) in a single white-space-only massive commit